### PR TITLE
Fix namespace imports in seed files

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Database\Seeder;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
 class DatabaseSeeder extends Seeder
 {
     /**

--- a/database/seeds/TalksSeeder.php
+++ b/database/seeds/TalksSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Database\Seeder;
+
 class TalksSeeder extends Seeder
 {
     public function run()

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Database\Seeder;
+
 class UserTableSeeder extends Seeder
 {
     public function run()


### PR DESCRIPTION
Laravel 5 doesn't alias `Seeder` or `Eloquent` anymore, so here's a quick fix :)