### PR TITLE
Conferences can be sorted by "closing next"

### DIFF
--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -21,7 +21,8 @@ class ConferencesController extends BaseController
     protected $sorting_conferences = [
         'date' => '',
         'alpha' => '',
-        'cfp_is_open' => ''
+        'cfp_is_open' => '',
+        'closing_next' => '',
     ];
 
     public function __construct()
@@ -62,6 +63,10 @@ class ConferencesController extends BaseController
                 $conferences->sortBy(function(Conference $model) {
                     return ! $model->cfpIsOpen();
                 });
+                break;
+            case 'closing_next':
+                $sorting_conference['closing_next'] = $bold_style;
+                $conferences = Conference::orderBy('cfp_ends_at', 'ASC')->get();
                 break;
             case 'alpha':
                 // Pass through

--- a/resources/views/conferences/index.blade.php
+++ b/resources/views/conferences/index.blade.php
@@ -14,6 +14,7 @@
         <p>Sort by: <a href="/conferences?sort=alpha"{{ $sorting_conference['alpha'] }}>Title</a>
             | <a href="/conferences?sort=date"{{ $sorting_conference['date'] }}>Date</a>
             | <a href="/conferences?sort=cfp_is_open"{{ $sorting_conference['cfp_is_open'] }}>CFP is Open</a>
+            | <a href="/conferences?sort=closing_next"{{ $sorting_conference['closing_next'] }}>Closing Next</a>
         </p>
         <ul class="list-conferences">
             @foreach ($conferences as $conference)


### PR DESCRIPTION
I thought it would be nice to sort conferences by "which CFPs are closing next" so you could have easy visibility on what you need to submit ASAP. Would recommend as the default personally.

This is just a first working version, followed existing patterns in place for sorting, but would like to clean up as a batch in another PR coming your way some time soon :)