### PR TITLE
Introduce CreateConferenceForm form object

### DIFF
--- a/app/Exceptions/ValidationException.php
+++ b/app/Exceptions/ValidationException.php
@@ -1,0 +1,20 @@
+<?php namespace SaveMyProposals\Exceptions;
+
+use RuntimeException;
+
+class ValidationException extends RuntimeException
+{
+    protected $errors;
+
+    public function __construct($message, $errors)
+    {
+        parent::__construct($message);
+        $this->errors = $errors;
+    }
+
+    public function errors()
+    {
+        return $this->errors;
+    }
+}
+

--- a/app/Services/CreateConferenceForm.php
+++ b/app/Services/CreateConferenceForm.php
@@ -1,0 +1,50 @@
+<?php namespace SaveMyProposals\Services;
+
+use Conference;
+use SaveMyProposals\Exceptions\ValidationException;
+use Validator;
+
+class CreateConferenceForm
+{
+    private $rules = [
+        'title' => ['required'],
+        'description' => ['required'],
+        'url' => ['required'],
+        'starts_at' => ['date'],
+        'ends_at' => ['date'],
+        'cfp_starts_at' => ['date'],
+        'cfp_ends_at' => ['date'],
+    ];
+
+    private $input;
+    private $user;
+
+    private function __construct($input, $user)
+    {
+        $this->input = $this->removeEmptyFields($input);
+        $this->user = $user;
+    }
+
+    private function removeEmptyFields($input)
+    {
+        return array_filter($input);
+    }
+
+    public static function fillOut($input, $user)
+    {
+        return new self($input, $user);
+    }
+
+    public function complete()
+    {
+        $validation = Validator::make($this->input, $this->rules);
+
+        if ($validation->fails()) {
+            throw new ValidationException('Invalid input provided, see errors', $validation->errors());
+        }
+
+        return Conference::create(array_merge($this->input, [
+            'author_id' => $this->user->id,
+        ]));
+    }
+}

--- a/app/models/Conference.php
+++ b/app/models/Conference.php
@@ -10,14 +10,23 @@ class Conference extends UuidBase
         'id'
     );
 
+    protected $fillable = [
+        'author_id',
+        'title',
+        'description',
+        'url',
+        'starts_at',
+        'ends_at',
+        'cfp_starts_at',
+        'cfp_ends_at',
+    ];
+
     protected $dates = [
         'starts_at',
         'ends_at',
         'cfp_starts_at',
         'cfp_ends_at'
     ];
-
-    public static $rules = [];
 
     public function author()
     {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.4.0",
         "phpspec/phpspec": "~2.1",
-        "laracasts/testdummy": "dev-master"
+        "laracasts/testdummy": "dev-master",
+        "mockery/mockery": "0.9.*@dev"
     },
     "autoload": {
         "classmap": [
@@ -36,7 +37,8 @@
     },
     "autoload-dev": {
         "classmap": [
-            "tests/TestCase.php"
+            "tests/TestCase.php",
+            "tests/IntegrationTestCase.php"
         ]
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4a848d5f672d055c55f1a150cd31084f",
+    "hash": "aaa83e5637fa192576c44531a6041b98",
     "packages": [
         {
             "name": "bugsnag/bugsnag",
@@ -2695,6 +2695,72 @@
             "time": "2015-01-18 22:34:19"
         },
         {
+            "name": "mockery/mockery",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/mockery.git",
+                "reference": "cce38ee95d444190e8aac2d46c6d5e7b94ea44ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/cce38ee95d444190e8aac2d46c6d5e7b94ea44ef",
+                "reference": "cce38ee95d444190e8aac2d46c6d5e7b94ea44ef",
+                "shasum": ""
+            },
+            "require": {
+                "lib-pcre": ">=7.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "hamcrest/hamcrest-php": "~1.1",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "~0.7@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
+            "homepage": "http://github.com/padraic/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2015-01-18 20:11:41"
+        },
+        {
             "name": "phpdocumentor/reflection-docblock",
             "version": "dev-master",
             "source": {
@@ -3654,7 +3720,8 @@
         "rexxars/joindin-client": 20,
         "guzzlehttp/guzzle": 20,
         "doctrine/dbal": 20,
-        "laracasts/testdummy": 20
+        "laracasts/testdummy": 20,
+        "mockery/mockery": 20
     },
     "prefer-stable": false,
     "platform": [],

--- a/tests/ConferenceTest.php
+++ b/tests/ConferenceTest.php
@@ -3,14 +3,8 @@
 use Laracasts\TestDummy\Factory;
 use Carbon\Carbon;
 
-class ConferenceTest extends TestCase
+class ConferenceTest extends IntegrationTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Artisan::call('migrate');
-    }
-
     /** @test */
     public function conferences_accept_proposals_during_the_call_for_papers()
     {

--- a/tests/CreateConferenceFormTest.php
+++ b/tests/CreateConferenceFormTest.php
@@ -1,0 +1,223 @@
+<?php
+
+use Laracasts\TestDummy\Factory;
+use SaveMyProposals\Exceptions\ValidationException;
+use SaveMyProposals\Services\CreateConferenceForm;
+
+class CreateConferenceFormTest extends IntegrationTestCase
+{
+    /**
+     * @test
+     * @expectedException SaveMyProposals\Exceptions\ValidationException
+     */
+    public function conference_title_is_required()
+    {
+        $input = [
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+    }
+
+    /**
+     * @test
+     * @expectedException SaveMyProposals\Exceptions\ValidationException
+     */
+    public function conference_description_is_required()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'url' => 'http://example.com',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+    }
+
+    /**
+     * @test
+     * @expectedException SaveMyProposals\Exceptions\ValidationException
+     */
+    public function conference_url_is_required()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+    }
+
+    /**
+     * @test
+     * @expectedException SaveMyProposals\Exceptions\ValidationException
+     */
+    public function conference_start_date_must_be_a_valid_date()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+            'starts_at' => 'potato',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+    }
+
+    /**
+     * @test
+     * @expectedException SaveMyProposals\Exceptions\ValidationException
+     */
+    public function conference_end_date_must_be_a_valid_date()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+            'ends_at' => 'potato',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+    }
+
+    /**
+     * @test
+     * @expectedException SaveMyProposals\Exceptions\ValidationException
+     */
+    public function conference_cfp_start_date_must_be_a_valid_date()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+            'cfp_starts_at' => 'potato',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+    }
+
+    /**
+     * @test
+     * @expectedException SaveMyProposals\Exceptions\ValidationException
+     */
+    public function conference_cfp_end_date_must_be_a_valid_date()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+            'cfp_ends_at' => 'potato',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_conference_with_the_minimum_required_input()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+
+        $conference = Conference::first();
+        $this->assertEquals('AwesomeConf 2015', $conference->title);
+        $this->assertEquals('The best conference in the world!', $conference->description);
+        $this->assertEquals('http://example.com', $conference->url);
+    }
+
+    /**
+     * @test
+     */
+    public function conference_dates_are_saved_if_provided()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+            'starts_at' => '2015-02-01',
+            'ends_at' => '2015-02-04',
+            'cfp_starts_at' => '2015-01-15',
+            'cfp_ends_at' => '2015-01-18',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+
+        $conference = Conference::first();
+        $this->assertEquals(new DateTime('2015-02-01'), $conference->starts_at);
+        $this->assertEquals(new DateTime('2015-02-04'), $conference->ends_at);
+        $this->assertEquals(new DateTime('2015-01-15'), $conference->cfp_starts_at);
+        $this->assertEquals(new DateTime('2015-01-18'), $conference->cfp_ends_at);
+    }
+
+    /**
+     * @test
+     */
+    public function empty_dates_are_treated_as_null()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+            'starts_at' => '',
+            'ends_at' => '',
+            'cfp_starts_at' => '',
+            'cfp_ends_at' => '',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $form->complete();
+
+        $conference = Conference::first();
+        $this->assertNull($conference->starts_at);
+        $this->assertNull($conference->ends_at);
+        $this->assertNull($conference->cfp_starts_at);
+        $this->assertNull($conference->cfp_ends_at);
+    }
+
+    /**
+     * @test
+     */
+    public function error_messages_are_available_if_creating_a_conference_fails()
+    {
+        $form = CreateConferenceForm::fillOut([], Factory::create('user'));
+
+        try {
+            $form->complete();
+        } catch (ValidationException $e) {
+            $this->assertNotEmpty($e->errors());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function completing_a_form_returns_the_new_conference()
+    {
+        $input = [
+            'title' => 'AwesomeConf 2015',
+            'description' => 'The best conference in the world!',
+            'url' => 'http://example.com',
+        ];
+
+        $form = CreateConferenceForm::fillOut($input, Factory::create('user'));
+        $conference = $form->complete();
+
+        $this->assertInstanceOf(Conference::class, $conference);
+        $this->assertNotNull($conference->id);
+    }
+}

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+class IntegrationTestCase extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        Artisan::call('migrate');
+    }
+}

--- a/tests/factories/factories.php
+++ b/tests/factories/factories.php
@@ -11,3 +11,10 @@ $factory('Conference', 'conference', [
     'cfp_starts_at' => new DateTime,
     'cfp_ends_at' => new DateTime,
 ]);
+
+$factory('User', 'user', [
+    'email' => 'example@example.com',
+    'password' => Hash::make('password'),
+    'first_name' => 'Jane',
+    'last_name' => 'Doe',
+]);


### PR DESCRIPTION
Pulled out the logic from the `ConferenceController@store` action into a form object. A little different than going the FormRequest route but I think these sorts of objects are nicer to test and easier to follow. You don't have to know anything about how the framework magically instantiates a certain request object or calls certain validation methods on it, etc.

Feel free to ignore if you want to use a FormRequest instead, it was fun either way :)